### PR TITLE
remove context from API

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -33,9 +33,9 @@ type mockMiddleware struct {
 }
 
 func (m *mockMiddleware) Exec(next cliware.Handler) cliware.Handler {
-	return cliware.HandlerFunc(func(ctx context.Context, req *http.Request) (*http.Response, error) {
+	return cliware.HandlerFunc(func(req *http.Request) (*http.Response, error) {
 		m.called = true
-		return next.Handle(ctx, req)
+		return next.Handle(req)
 	})
 }
 
@@ -75,9 +75,9 @@ func TestUseFunc(t *testing.T) {
 	client := gwc.New(dummyClient())
 	var called bool
 	client.UseFunc(func(next cliware.Handler) cliware.Handler {
-		return cliware.HandlerFunc(func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		return cliware.HandlerFunc(func(req *http.Request) (*http.Response, error) {
 			called = true
-			return next.Handle(ctx, req)
+			return next.Handle(req)
 		})
 	})
 	client.Get().Send()
@@ -100,9 +100,9 @@ func TestUsePostFunc(t *testing.T) {
 	client := gwc.New(dummyClient())
 	var called bool
 	client.UsePostFunc(func(next cliware.Handler) cliware.Handler {
-		return cliware.HandlerFunc(func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		return cliware.HandlerFunc(func(req *http.Request) (*http.Response, error) {
 			called = true
-			return next.Handle(ctx, req)
+			return next.Handle(req)
 		})
 	})
 	client.Get().Send()
@@ -115,15 +115,15 @@ func TestMiddlewareOrder(t *testing.T) {
 	client := gwc.New(dummyClient())
 	order := []string{}
 	client.UseFunc(func(next cliware.Handler) cliware.Handler {
-		return cliware.HandlerFunc(func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		return cliware.HandlerFunc(func(req *http.Request) (*http.Response, error) {
 			order = append(order, "pre")
-			return next.Handle(ctx, req)
+			return next.Handle(req)
 		})
 	})
 	client.UsePostFunc(func(next cliware.Handler) cliware.Handler {
-		return cliware.HandlerFunc(func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		return cliware.HandlerFunc(func(req *http.Request) (*http.Response, error) {
 			order = append(order, "post")
-			return next.Handle(ctx, req)
+			return next.Handle(req)
 		})
 	})
 	client.Get().Send()

--- a/request.go
+++ b/request.go
@@ -161,9 +161,8 @@ func (r *Request) BodyJSON(data interface{}) *Request {
 }
 
 // sendRequest is private method that does actual request dispatching.
-func (r *Request) sendRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
-	reqWithContext := req.WithContext(ctx)
-	return r.Client.client.Do(reqWithContext)
+func (r *Request) sendRequest(req *http.Request) (*http.Response, error) {
+	return r.Client.client.Do(req)
 }
 
 // Send constructs and sends HTTP request.
@@ -177,6 +176,7 @@ func (r *Request) Send() (*Response, error) {
 		r.context = context.Background()
 	}
 	r.context = clientToContext(r.context, r.Client.client)
-	resp, err := sender.Handle(r.context, cliware.EmptyRequest())
+	req := cliware.EmptyRequest().WithContext(r.context)
+	resp, err := sender.Handle(req)
 	return BuildResponse(resp, err), err
 }

--- a/request_test.go
+++ b/request_test.go
@@ -50,9 +50,9 @@ func TestRequest_UseFunc(t *testing.T) {
 	req := gwc.NewRequest(client, cliware.NewChain(), cliware.NewChain())
 	var called bool
 	req.UseFunc(func(next cliware.Handler) cliware.Handler {
-		return cliware.HandlerFunc(func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		return cliware.HandlerFunc(func(req *http.Request) (*http.Response, error) {
 			called = true
-			return next.Handle(ctx, req)
+			return next.Handle(req)
 		})
 	})
 	_, err := req.Send()


### PR DESCRIPTION
Request already has context, so providing an additional context.Context is redundant.
This pull request contains breaking API changes.